### PR TITLE
documentation for tailwind@4 and daisyui@5

### DIFF
--- a/packages/daisyui/README.md
+++ b/packages/daisyui/README.md
@@ -75,22 +75,16 @@ For dynamic theme switching, you can change the data-theme attribute in your app
 
 ## Tailwind Configuration
 
-Make sure your `tailwind.config.js` includes the DaisyUI plugin:
+Make sure your `src/index.css` includes the DaisyUI plugin:
 
-```js
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: ['./src/**/*.{js,jsx,ts,tsx}'],
-  theme: {
-    extend: {},
-  },
-  plugins: [require('daisyui')],
-  daisyui: {
-    themes: true,
-  },
-};
+```css
+@import 'tailwindcss';
+@source "../node_modules/@rjsf/daisyui";
+@plugin "daisyui" {
+  themes: all;
+}
 ```
-
+It's necessary to explicitely include the library as a source, as tailwindcss by [default](https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-registering-sources) ignores everything in `.gitignore` 
 ## Customization
 
 ### Grid Layout


### PR DESCRIPTION
### Reasons for making this change

Updating the documentation to make sure the theme works with Tailwind@4 and DaisyUI@5.
It's necessary to explicitly include the source to allow tailwind discovery of the classes in the module

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
